### PR TITLE
docs(community): add missing GitHub community files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+# Pull Request
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+
+- [ ] Test A
+- [ ] Test B
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have squashed my commits

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | -------------------|
+| 0.1.0   | :white_check_mark: |
+| 0.2.0   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+The KubeRocketCI team takes security vulnerabilities seriously. We appreciate your efforts to responsibly disclose your findings.
+
+To report a security vulnerability, please follow these steps:
+
+1. **DO NOT** disclose the vulnerability publicly on GitHub Issues or other public forums.
+2. Email us at <SupportEPMD-EDP@epam.com> with a detailed description of the vulnerability.
+3. Include steps to reproduce, impact, and any potential mitigations if known.
+4. Allow time for the team to investigate and address the vulnerability before any public disclosure.
+
+## What to expect
+
+- Acknowledgment of your report within 48 hours
+- An initial assessment of the report within 7 days
+- Regular updates about the progress of addressing the vulnerability
+- Credit for discovering the vulnerability (unless you prefer to remain anonymous)
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process:
+
+1. Once a vulnerability is confirmed, we develop and test a fix
+2. We prepare a security advisory to accompany the fix
+3. We release the fix and publish the security advisory simultaneously
+4. After the fix has been available for 10 days, details may be discussed publicly
+
+## Security Best Practices
+
+When deploying the tekton-custom-task controller:
+
+1. Use the principle of least privilege for the controller service account
+2. Keep your Kubernetes and Tekton environments updated with security patches
+3. Regularly review and audit access to the controller and its resources
+
+Thank you for helping us keep our project and our users secure!

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,33 @@
+# Support
+
+This document explains where and how to get help with the tekton-custom-task project.
+
+## Community Support
+
+### GitHub Discussions
+
+For questions, ideas, or general discussion about the project, please use our [GitHub Discussions](https://github.com/KubeRocketCI/docs/discussions).
+
+### GitHub Issues
+
+For bug reports and feature requests, please [create an issue](https://github.com/KubeRocketCI/tekton-custom-task/issues/new) using the appropriate template.
+
+## Documentation
+
+Before seeking help, please check our documentation:
+
+1. The [README.md](README.md) file for basic information
+2. The [docs/api.md](docs/api.md) file for detailed API information
+3. The [CONTRIBUTING.md](CONTRIBUTING.md) for development-related information
+
+## Community Channels
+
+- [GitHub Discussions](https://github.com/KubeRocketCI/docs/discussions)
+
+## Response Times
+
+- GitHub Issues: We aim to respond within 2-3 business days
+- GitHub Discussions: Community-based response times vary
+- Critical security issues: See our [SECURITY.md](SECURITY.md) file
+
+Thank you for your interest in our project!


### PR DESCRIPTION
- Add SECURITY.md with vulnerability reporting guidelines
- Add SUPPORT.md with support information
- Add pull request template for standardizing PR submissions